### PR TITLE
Implement TaskListScreen with FAB

### DIFF
--- a/TaskManagerApp/src/screens/TaskListScreen.js
+++ b/TaskManagerApp/src/screens/TaskListScreen.js
@@ -1,6 +1,68 @@
 // Screen that displays the list of tasks
+import React, { useEffect, useState } from 'react';
+import { View, StyleSheet, FlatList, TouchableOpacity, Text } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+
+import TaskItem from '../components/TaskItem';
+import { getTasks } from '../../utils/storage';
 
 export default function TaskListScreen() {
-  // TODO: implement task list screen
-  return null;
+  const [tasks, setTasks] = useState([]);
+  const navigation = useNavigation();
+
+  // Load tasks from storage when the screen mounts
+  useEffect(() => {
+    const load = async () => {
+      const stored = await getTasks();
+      setTasks(stored);
+    };
+    load();
+  }, []);
+
+  return (
+    <View style={styles.container}>
+      {/* Render the list of tasks */}
+      <FlatList
+        data={tasks}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => (
+          <TaskItem task={item} onToggle={() => {}} />
+        )}
+      />
+
+      {/* Floating action button to create a new task */}
+      <TouchableOpacity
+        style={styles.fab}
+        onPress={() => navigation.navigate('TaskFormScreen')}
+        accessibilityLabel="Add task"
+      >
+        <Text style={styles.fabText}>+</Text>
+      </TouchableOpacity>
+    </View>
+  );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    padding: 20,
+  },
+  fab: {
+    position: 'absolute',
+    right: 20,
+    bottom: 20,
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    backgroundColor: '#6200ee',
+    justifyContent: 'center',
+    alignItems: 'center',
+    elevation: 3,
+  },
+  fabText: {
+    color: '#fff',
+    fontSize: 32,
+    lineHeight: 34,
+  },
+});


### PR DESCRIPTION
## Summary
- implement UI logic for TaskListScreen
- load tasks on mount and show them with TaskItem
- add floating action button to go to TaskForm screen

## Testing
- `npm test` *(fails: "ReferenceError: You are trying to `import` a file outside of the scope of the test code" for Jest Expo)*

------
https://chatgpt.com/codex/tasks/task_e_686cfe800a64832da80eaf4950e8dfdc