### PR TITLE
Add custom icons with vector-icons

### DIFF
--- a/TaskManagerApp/jest-setup.js
+++ b/TaskManagerApp/jest-setup.js
@@ -1,0 +1,7 @@
+// Jest setup file to mock Expo vector icons
+jest.mock('@expo/vector-icons', () => {
+  const React = require('react');
+  return {
+    Ionicons: (props) => React.createElement('Ionicons', props),
+  };
+});

--- a/TaskManagerApp/package-lock.json
+++ b/TaskManagerApp/package-lock.json
@@ -8,6 +8,7 @@
       "name": "taskmanagerapp",
       "version": "1.0.0",
       "dependencies": {
+        "@expo/vector-icons": "^14.1.0",
         "@react-native-async-storage/async-storage": "2.1.2",
         "@react-native-community/checkbox": "^0.5.20",
         "expo": "~53.0.17",

--- a/TaskManagerApp/package.json
+++ b/TaskManagerApp/package.json
@@ -10,6 +10,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "@expo/vector-icons": "^14.1.0",
     "@react-native-async-storage/async-storage": "2.1.2",
     "@react-native-community/checkbox": "^0.5.20",
     "expo": "~53.0.17",
@@ -32,6 +33,7 @@
   },
   "private": true,
   "jest": {
-    "preset": "jest-expo"
+    "preset": "jest-expo",
+    "setupFilesAfterEnv": ["<rootDir>/jest-setup.js"]
   }
 }

--- a/TaskManagerApp/src/components/ChecklistItem.js
+++ b/TaskManagerApp/src/components/ChecklistItem.js
@@ -8,7 +8,7 @@ import {
   TouchableOpacity,
   useColorScheme,
 } from 'react-native';
-import CheckBox from '@react-native-community/checkbox';
+import { Ionicons } from '@expo/vector-icons';
 import Animated, { useSharedValue, useAnimatedStyle, withTiming } from 'react-native-reanimated';
 import * as Haptics from 'expo-haptics';
 import { theme, getNeumorphicStyle } from '../Theme';
@@ -69,12 +69,14 @@ export default function ChecklistItem({ item, onToggle, onEdit, onDelete }) {
         animatedStyle,
       ]}
     >
-      {/* Checkbox to mark the subtask as done */}
-      <CheckBox
-        value={item.completed}
-        onValueChange={handleToggle}
-        accessibilityLabel="checkbox"
-      />
+      {/* Checkmark icon toggles completion */}
+      <TouchableOpacity onPress={handleToggle} accessibilityLabel="Toggle subtask">
+        <Ionicons
+          name={item.completed ? 'checkmark-circle' : 'ellipse-outline'}
+          size={24}
+          color={theme.colors.accent}
+        />
+      </TouchableOpacity>
 
       {/* Title or text input depending on edit mode */}
       {editing ? (
@@ -93,15 +95,22 @@ export default function ChecklistItem({ item, onToggle, onEdit, onDelete }) {
       {/* Button to edit/save title */}
       <TouchableOpacity
         onPress={() => (editing ? saveEdit() : setEditing(true))}
-        accessibilityLabel="Edit subtask"
+        accessibilityLabel={editing ? 'Save subtask' : 'Edit subtask'}
       >
-        <Text style={styles.action}>{editing ? 'Save' : 'Edit'}</Text>
+        <Ionicons
+          name={editing ? 'checkmark' : 'pencil'}
+          size={20}
+          color={theme.colors.accent}
+        />
       </TouchableOpacity>
 
       {/* Optional delete button */}
       {onDelete && (
-        <TouchableOpacity onPress={() => onDelete(item.id)} accessibilityLabel="Delete subtask">
-          <Text style={styles.action}>Delete</Text>
+        <TouchableOpacity
+          onPress={() => onDelete(item.id)}
+          accessibilityLabel="Delete subtask"
+        >
+          <Ionicons name="trash-outline" size={20} color={theme.colors.accent} />
         </TouchableOpacity>
       )}
     </Animated.View>
@@ -132,9 +141,5 @@ const styles = StyleSheet.create({
     borderColor: theme.colors.accent,
     borderRadius: 4,
     padding: 4,
-  },
-  action: {
-    marginLeft: 10,
-    color: theme.colors.accent,
   },
 });

--- a/TaskManagerApp/src/components/TaskItem.js
+++ b/TaskManagerApp/src/components/TaskItem.js
@@ -2,6 +2,7 @@
 import React, { useEffect } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, Dimensions, useColorScheme } from 'react-native';
 import CheckBox from '@react-native-community/checkbox';
+import { Ionicons } from '@expo/vector-icons';
 import Animated, { useAnimatedStyle, useSharedValue, withTiming, runOnJS } from 'react-native-reanimated';
 import { Swipeable } from 'react-native-gesture-handler';
 import * as Haptics from 'expo-haptics';
@@ -58,7 +59,8 @@ export default function TaskItem({ task, onToggle, onDelete }) {
 
   const renderRightActions = () => (
     <View style={styles.deleteContainer}>
-      <Text style={styles.deleteText}>Eliminar</Text>
+      {/* Trash icon shown while swiping */}
+      <Ionicons name="trash-outline" size={24} color="#fff" />
     </View>
   );
 
@@ -122,9 +124,5 @@ const styles = StyleSheet.create({
     paddingHorizontal: 20,
     borderRadius: 12,
     marginVertical: 8,
-  },
-  deleteText: {
-    color: '#fff',
-    fontWeight: 'bold',
   },
 });

--- a/TaskManagerApp/src/components/__tests__/ChecklistItem.test.js
+++ b/TaskManagerApp/src/components/__tests__/ChecklistItem.test.js
@@ -5,26 +5,26 @@ import ChecklistItem from '../ChecklistItem';
 describe('ChecklistItem', () => {
   const item = { id: '1', title: 'Subtask', completed: false };
 
-  it('calls onToggle when checkbox value changes', () => {
+  it('calls onToggle when icon is pressed', () => {
     const onToggle = jest.fn();
     const { getByA11yLabel } = render(
       <ChecklistItem item={item} onToggle={onToggle} onEdit={() => {}} />
     );
 
-    fireEvent(getByA11yLabel('checkbox'), 'valueChange', true);
+    fireEvent.press(getByA11yLabel('Toggle subtask'));
     expect(onToggle).toHaveBeenCalledWith('1');
   });
 
   it('calls onEdit with new title when saved', () => {
     const onEdit = jest.fn();
-    const { getByText, getByDisplayValue } = render(
+    const { getByA11yLabel, getByDisplayValue } = render(
       <ChecklistItem item={item} onToggle={() => {}} onEdit={onEdit} />
     );
 
-    fireEvent.press(getByText('Edit'));
+    fireEvent.press(getByA11yLabel('Edit subtask'));
     const input = getByDisplayValue('Subtask');
     fireEvent.changeText(input, 'Updated');
-    fireEvent.press(getByText('Save'));
+    fireEvent.press(getByA11yLabel('Save subtask'));
 
     expect(onEdit).toHaveBeenCalledWith('1', 'Updated');
   });

--- a/TaskManagerApp/src/screens/TaskListScreen.js
+++ b/TaskManagerApp/src/screens/TaskListScreen.js
@@ -8,8 +8,15 @@ import {
   Text,
   useColorScheme,
 } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
 import { Snackbar } from 'react-native-paper';
-import Animated, { useSharedValue, useAnimatedStyle, withSpring } from 'react-native-reanimated';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withSpring,
+  withSequence,
+  withTiming,
+} from 'react-native-reanimated';
 import * as Haptics from 'expo-haptics';
 import { useNavigation } from '@react-navigation/native';
 
@@ -28,8 +35,13 @@ export default function TaskListScreen() {
   const [snackbarVisible, setSnackbarVisible] = useState(false);
   const scheme = useColorScheme();
   const fabScale = useSharedValue(1);
+  const fabRotation = useSharedValue(0);
+  // Animated style for the floating action button
   const fabAnimated = useAnimatedStyle(() => ({
-    transform: [{ scale: fabScale.value }],
+    transform: [
+      { scale: fabScale.value },
+      { rotate: `${fabRotation.value}deg` },
+    ],
   }));
   const navigation = useNavigation();
 
@@ -79,6 +91,10 @@ export default function TaskListScreen() {
     fabScale.value = withSpring(0.9, undefined, () => {
       fabScale.value = withSpring(1);
     });
+    fabRotation.value = withSequence(
+      withTiming(45, { duration: 150 }),
+      withTiming(0, { duration: 150 })
+    );
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
     navigation.navigate('TaskFormScreen');
   };
@@ -121,7 +137,8 @@ export default function TaskListScreen() {
         accessibilityLabel="Add task"
       >
         <Animated.View style={fabAnimated}>
-          <Text style={styles.fabText}>+</Text>
+          {/* Plus icon from Ionicons */}
+          <Ionicons name="add" size={32} color="#fff" />
         </Animated.View>
       </TouchableOpacity>
 
@@ -161,10 +178,5 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     elevation: 3,
-  },
-  fabText: {
-    color: '#fff',
-    fontSize: 32,
-    lineHeight: 34,
   },
 });


### PR DESCRIPTION
## Summary
- install @expo/vector-icons and configure Jest
- animate FAB with rotation
- use Ionicons for FAB, delete actions, subtask checks and editing
- mock vector icons in tests

## Testing
- `npm test` *(fails: ReferenceError due to expo modules)*

------
https://chatgpt.com/codex/tasks/task_e_686dab98816c832d9135ba9855537735